### PR TITLE
Correccion de bugs, REY COMIDO = JAQUE MATE y RESOLUCION DE BUG DE PIEZAS QUE COMEN A OTRAS QUE ESTAN EN UN CAGE

### DIFF
--- a/chess-game/assets/js/game.js
+++ b/chess-game/assets/js/game.js
@@ -1,7 +1,8 @@
 import { getAvailablePowerUpTypes, createPowerUpInstance } from './powerUpManager.js';
 import { ShieldPowerUp } from './powerups/ShieldPowerUp.js';
 import { ExtraMovePowerUp } from './powerups/ExtraMovePowerUp.js';
-import { EvolutionPowerUp } from './powerups/EvolutionPowerUp.js'; // NUEVO IMPORT
+import { EvolutionPowerUp } from './powerups/EvolutionPowerUp.js';
+import { CagePowerUp } from './powerups/CagePowerUp.js';
 
 /**
  * Processes active power-ups at the start of a player's turn.
@@ -113,7 +114,30 @@ export function handleClick(r, c, gameContext) {
         board[r][c].hasMoved = true;
         board[fr][fc] = null;
 
+        // NUEVA VERIFICACIÓN: Detectar captura del rey como jaque mate automático
+        if (capturedPiece && capturedPiece.type === 'k') {
+            // El rey ha sido capturado - jaque mate automático
+            const winnerColor = currentColor; // El jugador que capturó gana
+            const capturedKingColor = capturedPiece.color;
+            const winnerColorName = winnerColor === 'w' ? 'Blancas' : 'Negras';
+            const capturedKingColorName = capturedKingColor === 'w' ? 'Blancas' : 'Negras';
+            
+            if (gameContext.messageElement) {
+                gameContext.messageElement.textContent = `¡Rey de ${capturedKingColorName} capturado! ${winnerColorName} ganan la ronda.`;
+            }
+            
+            // Declarar ganador inmediatamente
+            gameContext.declareWinner(winnerColor);
+            gameContext.renderBoard();
+            return; // Terminar la función inmediatamente
+        }
 
+        // NUEVA VERIFICACIÓN: Limpiar cage si la pieza enjaulada fue capturada
+        if (capturedPiece) {
+            CagePowerUp.removeCageIfPieceCaptured(gameContext, r, c, capturedPiece);
+        }
+
+       
         // NUEVA INTEGRACIÓN: Actualizar Shield cuando se mueve una pieza
         if (gameContext.activePowerUps) {
             gameContext.activePowerUps.forEach(powerUp => {

--- a/chess-game/assets/js/powerups/CagePowerUp.js
+++ b/chess-game/assets/js/powerups/CagePowerUp.js
@@ -363,4 +363,56 @@ export class CagePowerUp extends PowerUpBase {
     targetCell.style.position = 'relative';
     targetCell.appendChild(cageEffect);
   }
+
+  /**
+   * NUEVO: Remueve la cage si la pieza enjaulada fue capturada.
+   */
+  static removeCageIfPieceCaptured(gameContext, captureRow, captureCol, capturedPiece) {
+    if (!gameContext.activePowerUps || !capturedPiece) return;
+
+    // Buscar si la pieza capturada tenía una jaula
+    const cageIndex = gameContext.activePowerUps.findIndex(powerUp => 
+        powerUp.type === 'Cage' && 
+        powerUp.targetRow === captureRow && 
+        powerUp.targetCol === captureCol &&
+        powerUp.remainingDuration > 0
+    );
+
+    if (cageIndex !== -1) {
+        const cage = gameContext.activePowerUps[cageIndex];
+        
+        // Remover visual de la jaula (aunque ya no esté la pieza)
+        const { boardElement } = gameContext;
+        if (boardElement) {
+            const targetCell = boardElement.querySelector(`[data-row="${captureRow}"][data-col="${captureCol}"]`);
+            if (targetCell) {
+                const cageElement = targetCell.querySelector('.cage-effect');
+                if (cageElement) {
+                    cageElement.remove();
+                }
+            }
+        }
+        
+        // Remover la cage de activePowerUps
+        gameContext.activePowerUps.splice(cageIndex, 1);
+        
+        // Mostrar mensaje (solo si no hay mensajes más importantes)
+        if (gameContext.messageElement) {
+            const pieceNames = {
+                'p': 'Peón', 'r': 'Torre', 'n': 'Caballo', 
+                'b': 'Alfil', 'q': 'Reina', 'k': 'Rey'
+            };
+            const pieceName = pieceNames[capturedPiece.type];
+            const capturedColorName = capturedPiece.color === 'w' ? 'Blancas' : 'Negras';
+            
+            // No sobreescribir mensajes importantes
+            if (!gameContext.messageElement.textContent.includes("capturado") && 
+                !gameContext.messageElement.textContent.includes("ganan la ronda")) {
+                gameContext.messageElement.textContent = `El ${pieceName} de ${capturedColorName} fue capturado. La jaula desaparece.`;
+            }
+        }
+        
+        console.log(`Cage removed: piece at (${captureRow}, ${captureCol}) was captured`);
+    }
+  }
 }


### PR DESCRIPTION

Implemente una funcionalidad antierrores para que en caso que el rey sea comido (por alguna condicion como extramove, cage, etc) este se marque como jaque mate y se tenga que avanzar a la siguiente ronda. Igualmente en cage corregi un bug donde si una pieza se comia a otra que estuviera encerrada en un cage esta ya no se podria mover hasta que desapareceria el cage. En lugar de esto, cuando una pieza encerrada es comida, tambien desaparece el cage.