### PR TITLE
Fix powerups

### DIFF
--- a/chess-game/assets/js/game.js
+++ b/chess-game/assets/js/game.js
@@ -457,17 +457,83 @@ export function handleClick(r, c, gameContext) {
 }
 
 /**
- * Selects a random power-up type from the available ones.
+ * Selects a random power-up type based on rarity weights.
  * @returns {string|null} The type name of the power-up, or null if none are available.
  */
 function getRandomPowerUp() {
+    // Define PowerUp rarities with their probabilities
+    const powerUpRarities = {
+        // COMUNES (75% total) - 18.75% cada uno
+        'Fence': 18.75,
+        'Shield': 18.75,
+        'Pawn Range': 18.75,
+        'Evolution': 18.75,
+        
+        // RAROS (20% total) - 6.67% cada uno
+        'Cage': 6.67,
+        'Blast': 6.67,
+        'Horizontal Portal': 6.66,
+        
+        // LEGENDARIOS (5% total) - 1.25% cada uno
+        'Extra Move': 1.25,
+        'Crazy King': 1.25,
+        'Reducer': 1.25,
+        'Swap': 1.25
+    };
+    
+    // Get available power-up types
     const availableTypes = getAvailablePowerUpTypes();
     if (availableTypes.length === 0) {
         console.warn("No power-up types available to grant.");
         return null;
     }
-    const randomIndex = Math.floor(Math.random() * availableTypes.length);
-    return availableTypes[randomIndex];
+    
+    // Filter rarities to only include available types
+    const availableRarities = {};
+    let totalWeight = 0;
+    
+    availableTypes.forEach(type => {
+        if (powerUpRarities[type]) {
+            availableRarities[type] = powerUpRarities[type];
+            totalWeight += powerUpRarities[type];
+        }
+    });
+    
+    if (totalWeight === 0) {
+        // Fallback to equal probability if no rarities defined
+        const randomIndex = Math.floor(Math.random() * availableTypes.length);
+        return availableTypes[randomIndex];
+    }
+    
+    // Generate random number and select based on weighted probability
+    const random = Math.random() * totalWeight;
+    let currentWeight = 0;
+    
+    for (const [type, weight] of Object.entries(availableRarities)) {
+        currentWeight += weight;
+        if (random <= currentWeight) {
+            return type;
+        }
+    }
+    
+    // Fallback (shouldn't reach here)
+    return availableTypes[0];
+}
+
+/**
+ * Gets the rarity level of a PowerUp
+ * @param {string} powerUpType - The type of the PowerUp
+ * @returns {string} The rarity level ('Común', 'Raro', 'Legendario')
+ */
+function getPowerUpRarity(powerUpType) {
+    const commonPowerUps = ['Fence', 'Shield', 'Pawn Range', 'Evolution'];
+    const rarePowerUps = ['Cage', 'Blast', 'Horizontal Portal'];
+    const legendaryPowerUps = ['Extra Move', 'Crazy King', 'Reducer', 'Swap'];
+    
+    if (commonPowerUps.includes(powerUpType)) return 'Común';
+    if (rarePowerUps.includes(powerUpType)) return 'Raro';
+    if (legendaryPowerUps.includes(powerUpType)) return 'Legendario';
+    return 'Común'; // Default
 }
 
 /**
@@ -502,10 +568,21 @@ function updateScoreWithPowerups(playerColor, gameContext, capturedPiece) {
             gameContext.gameStats.white.roundScore += points;
         }
         
-        if (gameContext.score1 >= gameContext.nextThresholdWhite) {
+        // CORREGIDO: Usar while loop para otorgar múltiples PowerUps
+        let powerUpsGranted = 0;
+        while (gameContext.score1 >= gameContext.nextThresholdWhite) {
             const newPowerUp = getRandomPowerUp();
-            if (newPowerUp) gameContext.grantPowerUp('w', newPowerUp);
+            if (newPowerUp) {
+                gameContext.grantPowerUp('w', newPowerUp);
+                powerUpsGranted++;
+            }
             gameContext.nextThresholdWhite += 5;
+        }
+        
+        // Mostrar mensaje si se otorgaron PowerUps
+        if (powerUpsGranted > 0 && gameContext.messageElement) {
+            const suffix = powerUpsGranted > 1 ? `s (${powerUpsGranted})` : '';
+            gameContext.messageElement.textContent = `¡Blancas obtienen PowerUp${suffix}!`;
         }
     } else { // 'b'
         gameContext.score2 += points;
@@ -516,10 +593,21 @@ function updateScoreWithPowerups(playerColor, gameContext, capturedPiece) {
             gameContext.gameStats.black.roundScore += points;
         }
         
-        if (gameContext.score2 >= gameContext.nextThresholdBlack) {
+        // CORREGIDO: Usar while loop para otorgar múltiples PowerUps
+        let powerUpsGranted = 0;
+        while (gameContext.score2 >= gameContext.nextThresholdBlack) {
             const newPowerUp = getRandomPowerUp();
-            if (newPowerUp) gameContext.grantPowerUp('b', newPowerUp);
+            if (newPowerUp) {
+                gameContext.grantPowerUp('b', newPowerUp);
+                powerUpsGranted++;
+            }
             gameContext.nextThresholdBlack += 5;
+        }
+        
+        // Mostrar mensaje si se otorgaron PowerUps
+        if (powerUpsGranted > 0 && gameContext.messageElement) {
+            const suffix = powerUpsGranted > 1 ? `s (${powerUpsGranted})` : '';
+            gameContext.messageElement.textContent = `¡Negras obtienen PowerUp${suffix}!`;
         }
     }
 }
@@ -618,14 +706,14 @@ export async function initGame(whitePlayerEmail, blackPlayerEmail) {
         },
         getCurrentPlayerId: function(color) {
             return this.playerIds[color];
-        },
-        // Agregar función grantPowerUp
+        },        // Agregar función grantPowerUp
         grantPowerUp: function(color, powerUpType) {
             if (!powerUpType) return;
             
             const inventory = color === 'w' ? this.powerUpsWhite : this.powerUpsBlack;
             const maxPowerUps = 5; // Límite de 5 powerups por jugador
             
+            // Verificar si el inventario está lleno
             if (inventory.length >= maxPowerUps) {
                 if (this.messageElement) {
                     this.messageElement.textContent = `${color === 'w' ? 'Blancas' : 'Negras'} tienen el máximo de power-ups (${maxPowerUps}).`;
@@ -633,12 +721,62 @@ export async function initGame(whitePlayerEmail, blackPlayerEmail) {
                 return;
             }
             
-            inventory.push(powerUpType);
+            let selectedPowerUp = powerUpType;
+            let attempts = 0;
+            const maxAttempts = 10; // Limite para evitar loops infinitos
+            
+            // Si el PowerUp ya existe en el inventario, intentar encontrar uno alternativo
+            while (inventory.includes(selectedPowerUp) && attempts < maxAttempts) {
+                if (attempts === 0 && this.messageElement) {
+                    const powerUpInfo = getPowerUpInfo(powerUpType);
+                    const powerUpName = powerUpInfo ? powerUpInfo.name : powerUpType;
+                    this.messageElement.textContent = 
+                        `${color === 'w' ? 'Blancas' : 'Negras'} ya tienen ${powerUpName}. Buscando alternativa...`;
+                }
+                
+                // Intentar seleccionar un PowerUp alternativo
+                selectedPowerUp = getRandomPowerUp();
+                attempts++;
+                
+                console.log(`Intento ${attempts}: PowerUp duplicado detectado (${powerUpType}), probando ${selectedPowerUp}`);
+            }
+            
+            // Si después de todos los intentos aún hay duplicado, no otorgar nada
+            if (inventory.includes(selectedPowerUp)) {
+                if (this.messageElement) {
+                    this.messageElement.textContent = 
+                        `${color === 'w' ? 'Blancas' : 'Negras'} tienen todos los PowerUps disponibles. No se otorga nada.`;
+                }
+                console.warn(`No se pudo encontrar PowerUp alternativo después de ${maxAttempts} intentos`);
+                return;
+            }
+            
+            // Agregar el PowerUp al inventario
+            inventory.push(selectedPowerUp);
             if (this.messageElement) {
-                const powerUpInfo = getPowerUpInfo(powerUpType);
-                const powerUpName = powerUpInfo ? powerUpInfo.name : powerUpType;
+                const powerUpInfo = getPowerUpInfo(selectedPowerUp);
+                const powerUpName = powerUpInfo ? powerUpInfo.name : selectedPowerUp;
+                const rarity = getPowerUpRarity(selectedPowerUp);
+                
+                // Emojis para rareza
+                const rarityEmoji = {
+                    'Común': '⚪',
+                    'Raro': '🔵', 
+                    'Legendario': '🟡'
+                };
+                
+                // Mostrar mensaje diferente si se otorgó un PowerUp alternativo
+                const isAlternative = selectedPowerUp !== powerUpType;
+                const messagePrefix = isAlternative ? 
+                    `¡${color === 'w' ? 'Blancas' : 'Negras'} obtienen (alternativo) ` : 
+                    `¡${color === 'w' ? 'Blancas' : 'Negras'} obtienen `;
+                
                 this.messageElement.textContent = 
-                    `¡${color === 'w' ? 'Blancas' : 'Negras'} obtienen power-up: ${powerUpName}!`;
+                    `${messagePrefix}${rarityEmoji[rarity]} ${powerUpName} (${rarity})!`;
+                    
+                if (isAlternative) {
+                    console.log(`PowerUp alternativo otorgado: ${selectedPowerUp} en lugar de ${powerUpType}`);
+                }
             }
             this.renderBoard(); // Para actualizar la UI de powerups
         }

--- a/chess-game/assets/js/powerups/BlastPowerUp.js
+++ b/chess-game/assets/js/powerups/BlastPowerUp.js
@@ -211,9 +211,7 @@ export class BlastPowerUp extends PowerUpBase {
       default: points = 0;
     }
 
-    console.log(`Blast: Adding ${points} points for ${eliminatedPiece.type}`);
-
-    if (points > 0) {
+    console.log(`Blast: Adding ${points} points for ${eliminatedPiece.type}`);    if (points > 0) {
       if (playerColor === 'w') {
         gameContext.score1 += points;
         const score1El = document.getElementById('score1');
@@ -221,10 +219,16 @@ export class BlastPowerUp extends PowerUpBase {
         
         console.log(`Blast: White score now ${gameContext.score1}, threshold ${gameContext.nextThresholdWhite}`);
         
-        // Verificar si se gana un nuevo power-up
-        if (gameContext.score1 >= gameContext.nextThresholdWhite) {
+        // CORREGIDO: Usar while loop para otorgar múltiples PowerUps
+        let powerUpsGranted = 0;
+        while (gameContext.score1 >= gameContext.nextThresholdWhite) {
           this.grantNewPowerUp(gameContext, 'w');
+          powerUpsGranted++;
           gameContext.nextThresholdWhite += 5;
+        }
+        
+        if (powerUpsGranted > 0) {
+          console.log(`Blast: Granted ${powerUpsGranted} PowerUp(s) to white`);
         }
       } else {
         gameContext.score2 += points;
@@ -233,10 +237,16 @@ export class BlastPowerUp extends PowerUpBase {
         
         console.log(`Blast: Black score now ${gameContext.score2}, threshold ${gameContext.nextThresholdBlack}`);
         
-        // Verificar si se gana un nuevo power-up
-        if (gameContext.score2 >= gameContext.nextThresholdBlack) {
+        // CORREGIDO: Usar while loop para otorgar múltiples PowerUps
+        let powerUpsGranted = 0;
+        while (gameContext.score2 >= gameContext.nextThresholdBlack) {
           this.grantNewPowerUp(gameContext, 'b');
+          powerUpsGranted++;
           gameContext.nextThresholdBlack += 5;
+        }
+        
+        if (powerUpsGranted > 0) {
+          console.log(`Blast: Granted ${powerUpsGranted} PowerUp(s) to black`);
         }
       }
     }

--- a/test_duplicate_prevention.js
+++ b/test_duplicate_prevention.js
@@ -1,0 +1,255 @@
+/**
+ * Test script para validar la prevención de duplicados y selección de PowerUps alternativos
+ */
+
+// Simulación de las funciones necesarias
+const powerUpRarities = {
+    'Fence': 18.75,
+    'Shield': 18.75,
+    'Pawn Range': 18.75,
+    'Evolution': 18.75,
+    'Cage': 6.67,
+    'Blast': 6.67,
+    'Horizontal Portal': 6.66,
+    'Extra Move': 1.25,
+    'Crazy King': 1.25,
+    'Reducer': 1.25,
+    'Swap': 1.25
+};
+
+function getAvailablePowerUpTypes() {
+    return Object.keys(powerUpRarities);
+}
+
+function getRandomPowerUp() {
+    const availableTypes = getAvailablePowerUpTypes();
+    const availableRarities = {};
+    let totalWeight = 0;
+    
+    availableTypes.forEach(type => {
+        if (powerUpRarities[type]) {
+            availableRarities[type] = powerUpRarities[type];
+            totalWeight += powerUpRarities[type];
+        }
+    });
+    
+    const random = Math.random() * totalWeight;
+    let currentWeight = 0;
+    
+    for (const [type, weight] of Object.entries(availableRarities)) {
+        currentWeight += weight;
+        if (random <= currentWeight) {
+            return type;
+        }
+    }
+    
+    return availableTypes[0];
+}
+
+function getPowerUpInfo(powerUpType) {
+    return { name: powerUpType };
+}
+
+function getPowerUpRarity(powerUpType) {
+    const commonPowerUps = ['Fence', 'Shield', 'Pawn Range', 'Evolution'];
+    const rarePowerUps = ['Cage', 'Blast', 'Horizontal Portal'];
+    const legendaryPowerUps = ['Extra Move', 'Crazy King', 'Reducer', 'Swap'];
+    
+    if (commonPowerUps.includes(powerUpType)) return 'Común';
+    if (rarePowerUps.includes(powerUpType)) return 'Raro';
+    if (legendaryPowerUps.includes(powerUpType)) return 'Legendario';
+    return 'Común';
+}
+
+// Simulación del gameContext con la nueva función grantPowerUp
+const gameContext = {
+    powerUpsWhite: [],
+    powerUpsBlack: [],
+    messageElement: { textContent: '' },
+    renderBoard: function() { /* simulación */ },
+    
+    grantPowerUp: function(color, powerUpType) {
+        if (!powerUpType) return;
+        
+        const inventory = color === 'w' ? this.powerUpsWhite : this.powerUpsBlack;
+        const maxPowerUps = 5;
+        
+        if (inventory.length >= maxPowerUps) {
+            if (this.messageElement) {
+                this.messageElement.textContent = `${color === 'w' ? 'Blancas' : 'Negras'} tienen el máximo de power-ups (${maxPowerUps}).`;
+            }
+            return;
+        }
+        
+        let selectedPowerUp = powerUpType;
+        let attempts = 0;
+        const maxAttempts = 10;
+        
+        while (inventory.includes(selectedPowerUp) && attempts < maxAttempts) {
+            if (attempts === 0 && this.messageElement) {
+                const powerUpInfo = getPowerUpInfo(powerUpType);
+                const powerUpName = powerUpInfo ? powerUpInfo.name : powerUpType;
+                this.messageElement.textContent = 
+                    `${color === 'w' ? 'Blancas' : 'Negras'} ya tienen ${powerUpName}. Buscando alternativa...`;
+            }
+            
+            selectedPowerUp = getRandomPowerUp();
+            attempts++;
+            
+            console.log(`Intento ${attempts}: PowerUp duplicado detectado (${powerUpType}), probando ${selectedPowerUp}`);
+        }
+        
+        if (inventory.includes(selectedPowerUp)) {
+            if (this.messageElement) {
+                this.messageElement.textContent = 
+                    `${color === 'w' ? 'Blancas' : 'Negras'} tienen todos los PowerUps disponibles. No se otorga nada.`;
+            }
+            console.warn(`No se pudo encontrar PowerUp alternativo después de ${maxAttempts} intentos`);
+            return;
+        }
+        
+        inventory.push(selectedPowerUp);
+        if (this.messageElement) {
+            const powerUpInfo = getPowerUpInfo(selectedPowerUp);
+            const powerUpName = powerUpInfo ? powerUpInfo.name : selectedPowerUp;
+            const rarity = getPowerUpRarity(selectedPowerUp);
+            
+            const rarityEmoji = {
+                'Común': '⚪',
+                'Raro': '🔵', 
+                'Legendario': '🟡'
+            };
+            
+            const isAlternative = selectedPowerUp !== powerUpType;
+            const messagePrefix = isAlternative ? 
+                `¡${color === 'w' ? 'Blancas' : 'Negras'} obtienen (alternativo) ` : 
+                `¡${color === 'w' ? 'Blancas' : 'Negras'} obtienen `;
+            
+            this.messageElement.textContent = 
+                `${messagePrefix}${rarityEmoji[rarity]} ${powerUpName} (${rarity})!`;
+                
+            if (isAlternative) {
+                console.log(`PowerUp alternativo otorgado: ${selectedPowerUp} en lugar de ${powerUpType}`);
+            }
+        }
+        
+        this.renderBoard();
+    }
+};
+
+// Tests
+console.log('🧪 Iniciando pruebas de prevención de duplicados...\n');
+
+// Test 1: Otorgar PowerUps únicos inicialmente
+console.log('Test 1: Otorgando PowerUps únicos');
+console.log('='.repeat(40));
+
+gameContext.grantPowerUp('w', 'Fence');
+console.log(`Blancas: [${gameContext.powerUpsWhite.join(', ')}]`);
+console.log(`Mensaje: ${gameContext.messageElement.textContent}\n`);
+
+gameContext.grantPowerUp('w', 'Shield');
+console.log(`Blancas: [${gameContext.powerUpsWhite.join(', ')}]`);
+console.log(`Mensaje: ${gameContext.messageElement.textContent}\n`);
+
+// Test 2: Intentar otorgar PowerUp duplicado
+console.log('Test 2: Intentando otorgar PowerUp duplicado');
+console.log('='.repeat(40));
+
+console.log('Intentando otorgar Fence (duplicado)...');
+gameContext.grantPowerUp('w', 'Fence');
+console.log(`Blancas: [${gameContext.powerUpsWhite.join(', ')}]`);
+console.log(`Mensaje: ${gameContext.messageElement.textContent}\n`);
+
+// Test 3: Llenar inventario gradualmente
+console.log('Test 3: Llenando inventario gradualmente');
+console.log('='.repeat(40));
+
+const powerUpsToTry = ['Cage', 'Blast', 'Extra Move', 'Crazy King'];
+powerUpsToTry.forEach(powerUp => {
+    console.log(`Otorgando ${powerUp}...`);
+    gameContext.grantPowerUp('w', powerUp);
+    console.log(`Blancas: [${gameContext.powerUpsWhite.join(', ')}]`);
+    console.log(`Mensaje: ${gameContext.messageElement.textContent}\n`);
+});
+
+// Test 4: Intentar otorgar cuando inventario está lleno
+console.log('Test 4: Inventario lleno - intentando otorgar más PowerUps');
+console.log('='.repeat(40));
+
+console.log('Intentando otorgar Horizontal Portal cuando hay 5 PowerUps...');
+gameContext.grantPowerUp('w', 'Horizontal Portal');
+console.log(`Blancas: [${gameContext.powerUpsWhite.join(', ')}]`);
+console.log(`Mensaje: ${gameContext.messageElement.textContent}\n`);
+
+// Test 5: Caso extremo - todos los PowerUps en inventario
+console.log('Test 5: Caso extremo - inventario con todos los PowerUps disponibles');
+console.log('='.repeat(40));
+
+// Simular inventario completo (solo para test)
+const testContext = {
+    powerUpsWhite: getAvailablePowerUpTypes(),
+    powerUpsBlack: [],
+    messageElement: { textContent: '' },
+    renderBoard: gameContext.renderBoard,
+    grantPowerUp: gameContext.grantPowerUp
+};
+
+console.log(`PowerUps disponibles: ${getAvailablePowerUpTypes().length}`);
+console.log(`Inventario simulado: [${testContext.powerUpsWhite.join(', ')}]`);
+console.log('Intentando otorgar cualquier PowerUp...');
+testContext.grantPowerUp.call(testContext, 'w', 'Fence');
+console.log(`Mensaje: ${testContext.messageElement.textContent}\n`);
+
+// Test 6: Estadísticas de alternativas
+console.log('Test 6: Estadísticas de PowerUps alternativos');
+console.log('='.repeat(40));
+
+const freshContext = {
+    powerUpsWhite: ['Fence', 'Shield'], // Ya tiene 2 PowerUps
+    powerUpsBlack: [],
+    messageElement: { textContent: '' },
+    renderBoard: gameContext.renderBoard,
+    grantPowerUp: gameContext.grantPowerUp
+};
+
+let alternativeCount = 0;
+let totalAttempts = 0;
+
+for (let i = 0; i < 20; i++) {
+    const initialLength = freshContext.powerUpsWhite.length;
+    const randomPowerUp = getRandomPowerUp();
+    
+    console.log(`Intento ${i + 1}: Otorgando ${randomPowerUp}...`);
+    freshContext.grantPowerUp.call(freshContext, 'w', randomPowerUp);
+    
+    totalAttempts++;
+    if (freshContext.powerUpsWhite.length > initialLength) {
+        const addedPowerUp = freshContext.powerUpsWhite[freshContext.powerUpsWhite.length - 1];
+        if (addedPowerUp !== randomPowerUp) {
+            alternativeCount++;
+            console.log(`  ➜ Alternativo otorgado: ${addedPowerUp} (solicitado: ${randomPowerUp})`);
+        } else {
+            console.log(`  ➜ PowerUp original otorgado: ${addedPowerUp}`);
+        }
+    } else {
+        console.log(`  ➜ No se otorgó PowerUp (duplicado o inventario lleno)`);
+    }
+    
+    console.log(`  Inventario actual: [${freshContext.powerUpsWhite.join(', ')}]`);
+    console.log(`  Mensaje: ${freshContext.messageElement.textContent}\n`);
+    
+    // Parar cuando el inventario esté lleno
+    if (freshContext.powerUpsWhite.length >= 5) {
+        console.log('Inventario lleno alcanzado.');
+        break;
+    }
+}
+
+console.log('📊 Resumen de estadísticas:');
+console.log(`- Total de intentos: ${totalAttempts}`);
+console.log(`- PowerUps alternativos otorgados: ${alternativeCount}`);
+console.log(`- Porcentaje de alternativas: ${((alternativeCount / totalAttempts) * 100).toFixed(1)}%`);
+console.log(`- Inventario final: [${freshContext.powerUpsWhite.join(', ')}]`);
+
+console.log('\n✅ Pruebas de prevención de duplicados completadas!');

--- a/test_powerup_complete.html
+++ b/test_powerup_complete.html
@@ -1,0 +1,435 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test de PowerUps - Prevención de Duplicados</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            background: #1a1a1a;
+            color: #ffffff;
+        }
+        .test-section {
+            margin: 20px 0;
+            padding: 20px;
+            border: 1px solid #444;
+            border-radius: 8px;
+            background: #2a2a2a;
+        }
+        .test-section h2 {
+            color: #4CAF50;
+            margin-top: 0;
+        }
+        .test-results {
+            background: #1e1e1e;
+            padding: 15px;
+            border-radius: 5px;
+            margin: 10px 0;
+            border-left: 4px solid #4CAF50;
+        }
+        .error {
+            border-left-color: #f44336;
+            background: #2a1a1a;
+        }
+        .warning {
+            border-left-color: #ff9800;
+            background: #2a2a1a;
+        }
+        .button {
+            background: #4CAF50;
+            color: white;
+            border: none;
+            padding: 10px 20px;
+            border-radius: 5px;
+            cursor: pointer;
+            margin: 5px;
+        }
+        .button:hover {
+            background: #45a049;
+        }
+        .inventory {
+            background: #333;
+            padding: 10px;
+            border-radius: 5px;
+            margin: 10px 0;
+            font-family: monospace;
+        }
+        .log-entry {
+            margin: 5px 0;
+            padding: 5px;
+            border-radius: 3px;
+        }
+        .log-success { background: #1b4332; }
+        .log-warning { background: #7d4f00; }
+        .log-error { background: #4d1a1a; }
+        .stats {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 15px;
+            margin: 20px 0;
+        }
+        .stat-card {
+            background: #333;
+            padding: 15px;
+            border-radius: 8px;
+            text-align: center;
+        }
+        .stat-value {
+            font-size: 2em;
+            font-weight: bold;
+            color: #4CAF50;
+        }
+        .powerup-item {
+            display: inline-block;
+            background: #4CAF50;
+            color: white;
+            padding: 5px 10px;
+            margin: 2px;
+            border-radius: 15px;
+            font-size: 0.9em;
+        }
+    </style>
+</head>
+<body>
+    <h1>🧪 Test de Sistema de PowerUps - Prevención de Duplicados</h1>
+    
+    <div class="test-section">
+        <h2>📊 Estadísticas de Prueba</h2>
+        <div class="stats">
+            <div class="stat-card">
+                <div class="stat-value" id="totalAttempts">0</div>
+                <div>Intentos Totales</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-value" id="successfulGrants">0</div>
+                <div>PowerUps Otorgados</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-value" id="alternativeCount">0</div>
+                <div>Alternativos</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-value" id="duplicateBlocks">0</div>
+                <div>Duplicados Bloqueados</div>
+            </div>
+        </div>
+    </div>
+
+    <div class="test-section">
+        <h2>🎮 Inventarios de Jugadores</h2>
+        <div>
+            <h3>Jugador Blanco:</h3>
+            <div class="inventory" id="whiteInventory">Vacío</div>
+        </div>
+        <div>
+            <h3>Jugador Negro:</h3>
+            <div class="inventory" id="blackInventory">Vacío</div>
+        </div>
+    </div>
+
+    <div class="test-section">
+        <h2>🔧 Controles de Prueba</h2>
+        <button class="button" onclick="runBasicTest()">Test Básico</button>
+        <button class="button" onclick="runDuplicateTest()">Test de Duplicados</button>
+        <button class="button" onclick="runAlternativeTest()">Test de Alternativos</button>
+        <button class="button" onclick="runStressTest()">Test de Estrés</button>
+        <button class="button" onclick="clearAll()">Limpiar Todo</button>
+    </div>
+
+    <div class="test-section">
+        <h2>📝 Log de Eventos</h2>
+        <div id="testLog" class="test-results"></div>
+    </div>
+
+    <div class="test-section">
+        <h2>🎯 Último Mensaje del Sistema</h2>
+        <div id="systemMessage" class="test-results">Sistema listo para pruebas</div>
+    </div>
+
+    <script>
+        // Simulación del sistema de PowerUps
+        const powerUpRarities = {
+            'Fence': 18.75,
+            'Shield': 18.75,
+            'Pawn Range': 18.75,
+            'Evolution': 18.75,
+            'Cage': 6.67,
+            'Blast': 6.67,
+            'Horizontal Portal': 6.66,
+            'Extra Move': 1.25,
+            'Crazy King': 1.25,
+            'Reducer': 1.25,
+            'Swap': 1.25
+        };
+
+        let stats = {
+            totalAttempts: 0,
+            successfulGrants: 0,
+            alternativeCount: 0,
+            duplicateBlocks: 0
+        };
+
+        function getAvailablePowerUpTypes() {
+            return Object.keys(powerUpRarities);
+        }
+
+        function getRandomPowerUp() {
+            const availableTypes = getAvailablePowerUpTypes();
+            const availableRarities = {};
+            let totalWeight = 0;
+            
+            availableTypes.forEach(type => {
+                if (powerUpRarities[type]) {
+                    availableRarities[type] = powerUpRarities[type];
+                    totalWeight += powerUpRarities[type];
+                }
+            });
+            
+            const random = Math.random() * totalWeight;
+            let currentWeight = 0;
+            
+            for (const [type, weight] of Object.entries(availableRarities)) {
+                currentWeight += weight;
+                if (random <= currentWeight) {
+                    return type;
+                }
+            }
+            
+            return availableTypes[0];
+        }
+
+        function getPowerUpInfo(powerUpType) {
+            return { name: powerUpType };
+        }
+
+        function getPowerUpRarity(powerUpType) {
+            const commonPowerUps = ['Fence', 'Shield', 'Pawn Range', 'Evolution'];
+            const rarePowerUps = ['Cage', 'Blast', 'Horizontal Portal'];
+            const legendaryPowerUps = ['Extra Move', 'Crazy King', 'Reducer', 'Swap'];
+            
+            if (commonPowerUps.includes(powerUpType)) return 'Común';
+            if (rarePowerUps.includes(powerUpType)) return 'Raro';
+            if (legendaryPowerUps.includes(powerUpType)) return 'Legendario';
+            return 'Común';
+        }
+
+        // Sistema de inventarios
+        const gameContext = {
+            powerUpsWhite: [],
+            powerUpsBlack: [],
+            messageElement: { textContent: '' },
+            
+            grantPowerUp: function(color, powerUpType) {
+                stats.totalAttempts++;
+                
+                if (!powerUpType) {
+                    logEvent('ERROR: PowerUp tipo nulo', 'error');
+                    return;
+                }
+                
+                const inventory = color === 'w' ? this.powerUpsWhite : this.powerUpsBlack;
+                const maxPowerUps = 5;
+                
+                if (inventory.length >= maxPowerUps) {
+                    this.messageElement.textContent = `${color === 'w' ? 'Blancas' : 'Negras'} tienen el máximo de power-ups (${maxPowerUps}).`;
+                    logEvent(`Inventario lleno para ${color === 'w' ? 'Blancas' : 'Negras'}`, 'warning');
+                    updateDisplay();
+                    return;
+                }
+                
+                let selectedPowerUp = powerUpType;
+                let attempts = 0;
+                const maxAttempts = 10;
+                
+                while (inventory.includes(selectedPowerUp) && attempts < maxAttempts) {
+                    if (attempts === 0) {
+                        const powerUpInfo = getPowerUpInfo(powerUpType);
+                        const powerUpName = powerUpInfo ? powerUpInfo.name : powerUpType;
+                        this.messageElement.textContent = 
+                            `${color === 'w' ? 'Blancas' : 'Negras'} ya tienen ${powerUpName}. Buscando alternativa...`;
+                        
+                        stats.duplicateBlocks++;
+                        logEvent(`Duplicado detectado: ${powerUpType}`, 'warning');
+                    }
+                    
+                    selectedPowerUp = getRandomPowerUp();
+                    attempts++;
+                    
+                    logEvent(`Intento ${attempts}: Probando ${selectedPowerUp}`, 'info');
+                }
+                
+                if (inventory.includes(selectedPowerUp)) {
+                    this.messageElement.textContent = 
+                        `${color === 'w' ? 'Blancas' : 'Negras'} tienen todos los PowerUps disponibles. No se otorga nada.`;
+                    
+                    logEvent(`No se pudo encontrar alternativa después de ${maxAttempts} intentos`, 'error');
+                    updateDisplay();
+                    return;
+                }
+                
+                inventory.push(selectedPowerUp);
+                stats.successfulGrants++;
+                
+                const powerUpInfo = getPowerUpInfo(selectedPowerUp);
+                const powerUpName = powerUpInfo ? powerUpInfo.name : selectedPowerUp;
+                const rarity = getPowerUpRarity(selectedPowerUp);
+                
+                const rarityEmoji = {
+                    'Común': '⚪',
+                    'Raro': '🔵', 
+                    'Legendario': '🟡'
+                };
+                
+                const isAlternative = selectedPowerUp !== powerUpType;
+                if (isAlternative) {
+                    stats.alternativeCount++;
+                }
+                
+                const messagePrefix = isAlternative ? 
+                    `¡${color === 'w' ? 'Blancas' : 'Negras'} obtienen (alternativo) ` : 
+                    `¡${color === 'w' ? 'Blancas' : 'Negras'} obtienen `;
+                
+                this.messageElement.textContent = 
+                    `${messagePrefix}${rarityEmoji[rarity]} ${powerUpName} (${rarity})!`;
+                
+                if (isAlternative) {
+                    logEvent(`PowerUp alternativo otorgado: ${selectedPowerUp} en lugar de ${powerUpType}`, 'success');
+                } else {
+                    logEvent(`PowerUp otorgado: ${selectedPowerUp}`, 'success');
+                }
+                
+                updateDisplay();
+            }
+        };
+
+        function logEvent(message, type = 'info') {
+            const logContainer = document.getElementById('testLog');
+            const logEntry = document.createElement('div');
+            logEntry.className = `log-entry log-${type}`;
+            logEntry.textContent = `[${new Date().toLocaleTimeString()}] ${message}`;
+            logContainer.appendChild(logEntry);
+            logContainer.scrollTop = logContainer.scrollHeight;
+        }
+
+        function updateDisplay() {
+            // Actualizar estadísticas
+            document.getElementById('totalAttempts').textContent = stats.totalAttempts;
+            document.getElementById('successfulGrants').textContent = stats.successfulGrants;
+            document.getElementById('alternativeCount').textContent = stats.alternativeCount;
+            document.getElementById('duplicateBlocks').textContent = stats.duplicateBlocks;
+            
+            // Actualizar inventarios
+            const whiteInv = document.getElementById('whiteInventory');
+            const blackInv = document.getElementById('blackInventory');
+            
+            whiteInv.innerHTML = gameContext.powerUpsWhite.length === 0 ? 'Vacío' : 
+                gameContext.powerUpsWhite.map(p => `<span class="powerup-item">${p}</span>`).join('');
+            
+            blackInv.innerHTML = gameContext.powerUpsBlack.length === 0 ? 'Vacío' : 
+                gameContext.powerUpsBlack.map(p => `<span class="powerup-item">${p}</span>`).join('');
+            
+            // Actualizar mensaje del sistema
+            document.getElementById('systemMessage').textContent = gameContext.messageElement.textContent;
+        }
+
+        function runBasicTest() {
+            logEvent('=== INICIANDO TEST BÁSICO ===', 'info');
+            
+            // Otorgar algunos PowerUps únicos
+            gameContext.grantPowerUp('w', 'Fence');
+            gameContext.grantPowerUp('w', 'Shield');
+            gameContext.grantPowerUp('b', 'Cage');
+            gameContext.grantPowerUp('b', 'Blast');
+            
+            logEvent('Test básico completado', 'success');
+        }
+
+        function runDuplicateTest() {
+            logEvent('=== INICIANDO TEST DE DUPLICADOS ===', 'info');
+            
+            // Intentar otorgar PowerUps que ya existen
+            const whitePowerUps = gameContext.powerUpsWhite;
+            if (whitePowerUps.length > 0) {
+                const existingPowerUp = whitePowerUps[0];
+                logEvent(`Intentando otorgar duplicado: ${existingPowerUp}`, 'info');
+                gameContext.grantPowerUp('w', existingPowerUp);
+            } else {
+                // Si no hay PowerUps, agregar uno y luego intentar duplicarlo
+                gameContext.grantPowerUp('w', 'Evolution');
+                gameContext.grantPowerUp('w', 'Evolution');
+            }
+            
+            logEvent('Test de duplicados completado', 'success');
+        }
+
+        function runAlternativeTest() {
+            logEvent('=== INICIANDO TEST DE ALTERNATIVOS ===', 'info');
+            
+            // Llenar parcialmente el inventario y luego intentar otorgar duplicados
+            const targetPowerUps = ['Fence', 'Shield', 'Cage'];
+            
+            targetPowerUps.forEach(powerUp => {
+                if (!gameContext.powerUpsWhite.includes(powerUp)) {
+                    gameContext.grantPowerUp('w', powerUp);
+                }
+            });
+            
+            // Ahora intentar otorgar duplicados para forzar alternativas
+            targetPowerUps.forEach(powerUp => {
+                logEvent(`Intentando duplicado para forzar alternativa: ${powerUp}`, 'info');
+                gameContext.grantPowerUp('w', powerUp);
+            });
+            
+            logEvent('Test de alternativos completado', 'success');
+        }
+
+        function runStressTest() {
+            logEvent('=== INICIANDO TEST DE ESTRÉS ===', 'info');
+            
+            // Intentar otorgar muchos PowerUps aleatorios
+            for (let i = 0; i < 20; i++) {
+                const randomPowerUp = getRandomPowerUp();
+                const randomPlayer = Math.random() > 0.5 ? 'w' : 'b';
+                
+                logEvent(`Estrés ${i + 1}/20: Otorgando ${randomPowerUp} a ${randomPlayer === 'w' ? 'Blancas' : 'Negras'}`, 'info');
+                gameContext.grantPowerUp(randomPlayer, randomPowerUp);
+                
+                // Pequeña pausa visual
+                if (i % 5 === 0) {
+                    setTimeout(() => {}, 100);
+                }
+            }
+            
+            logEvent('Test de estrés completado', 'success');
+        }
+
+        function clearAll() {
+            gameContext.powerUpsWhite = [];
+            gameContext.powerUpsBlack = [];
+            gameContext.messageElement.textContent = 'Sistema reiniciado';
+            
+            stats = {
+                totalAttempts: 0,
+                successfulGrants: 0,
+                alternativeCount: 0,
+                duplicateBlocks: 0
+            };
+            
+            document.getElementById('testLog').innerHTML = '';
+            
+            updateDisplay();
+            logEvent('=== SISTEMA REINICIADO ===', 'info');
+        }
+
+        // Inicialización
+        document.addEventListener('DOMContentLoaded', function() {
+            updateDisplay();
+            logEvent('Sistema de pruebas inicializado', 'success');
+        });
+    </script>
+</body>
+</html>

--- a/test_powerup_logic.js
+++ b/test_powerup_logic.js
@@ -1,0 +1,87 @@
+// Test simple para verificar la lógica de PowerUps múltiples
+console.log("=== Test de lógica de PowerUps múltiples ===");
+
+// Simular contexto de juego
+const mockGameContext = {
+    score1: 4, // Jugador blanco tiene 4 puntos
+    score2: 2, // Jugador negro tiene 2 puntos
+    nextThresholdWhite: 5, // Próximo umbral para blanco
+    nextThresholdBlack: 5, // Próximo umbral para negro
+    grantedPowerUps: [], // Para trackear PowerUps otorgados
+    grantPowerUp: function(player, powerUp) {
+        this.grantedPowerUps.push({player, powerUp});
+        console.log(`✓ PowerUp otorgado: ${powerUp} para ${player}`);
+    }
+};
+
+// Función simplificada para obtener PowerUp aleatorio
+function getRandomPowerUp() {
+    const powerUps = ['Fence', 'Shield', 'Blast', 'Portal'];
+    return powerUps[Math.floor(Math.random() * powerUps.length)];
+}
+
+// Simular la lógica corregida
+function simulateScoreUpdate(playerColor, points, gameContext) {
+    console.log(`\n--- ${playerColor === 'w' ? 'Blanco' : 'Negro'} gana ${points} puntos ---`);
+    console.log(`Puntuación antes: ${playerColor === 'w' ? gameContext.score1 : gameContext.score2}`);
+    
+    if (playerColor === 'w') {
+        gameContext.score1 += points;
+        console.log(`Puntuación después: ${gameContext.score1}`);
+        console.log(`Umbral actual: ${gameContext.nextThresholdWhite}`);
+        
+        // Calculate how many PowerUps should be granted
+        let powerUpsGranted = 0;
+        while (gameContext.score1 >= gameContext.nextThresholdWhite) {
+            const newPowerUp = getRandomPowerUp();
+            if (newPowerUp) {
+                gameContext.grantPowerUp('w', newPowerUp);
+                powerUpsGranted++;
+            }
+            gameContext.nextThresholdWhite += 5;
+        }
+        console.log(`PowerUps otorgados: ${powerUpsGranted}`);
+        console.log(`Próximo umbral: ${gameContext.nextThresholdWhite}`);
+    } else { // 'b'
+        gameContext.score2 += points;
+        console.log(`Puntuación después: ${gameContext.score2}`);
+        console.log(`Umbral actual: ${gameContext.nextThresholdBlack}`);
+        
+        // Calculate how many PowerUps should be granted
+        let powerUpsGranted = 0;
+        while (gameContext.score2 >= gameContext.nextThresholdBlack) {
+            const newPowerUp = getRandomPowerUp();
+            if (newPowerUp) {
+                gameContext.grantPowerUp('b', newPowerUp);
+                powerUpsGranted++;
+            }
+            gameContext.nextThresholdBlack += 5;
+        }
+        console.log(`PowerUps otorgados: ${powerUpsGranted}`);
+        console.log(`Próximo umbral: ${gameContext.nextThresholdBlack}`);
+    }
+}
+
+// Test 1: Jugador blanco captura reina (9 puntos) - debería obtener 2 PowerUps
+console.log("\n🧪 TEST 1: Blanco captura reina (9 puntos)");
+console.log("Esperado: 2 PowerUps (4+9=13 puntos, cruza umbrales 5 y 10)");
+simulateScoreUpdate('w', 9, mockGameContext);
+
+// Test 2: Jugador negro captura torre (6 puntos) - debería obtener 1 PowerUp
+console.log("\n🧪 TEST 2: Negro captura torre (6 puntos)");
+console.log("Esperado: 1 PowerUp (2+6=8 puntos, cruza umbral 5)");
+simulateScoreUpdate('b', 6, mockGameContext);
+
+// Test 3: Jugador blanco captura peón (2 puntos) - no debería obtener PowerUp
+console.log("\n🧪 TEST 3: Blanco captura peón (2 puntos)");
+console.log("Esperado: 0 PowerUps (13+2=15 puntos, no cruza umbral 15)");
+simulateScoreUpdate('w', 2, mockGameContext);
+
+console.log("\n=== Resumen de PowerUps otorgados ===");
+mockGameContext.grantedPowerUps.forEach((grant, index) => {
+    console.log(`${index + 1}. ${grant.powerUp} para ${grant.player}`);
+});
+
+console.log("\n=== Estado final ===");
+console.log(`Blanco: ${mockGameContext.score1} puntos (próximo umbral: ${mockGameContext.nextThresholdWhite})`);
+console.log(`Negro: ${mockGameContext.score2} puntos (próximo umbral: ${mockGameContext.nextThresholdBlack})`);

--- a/test_powerup_rarity.js
+++ b/test_powerup_rarity.js
@@ -1,0 +1,137 @@
+/**
+ * Test script para verificar las probabilidades de rareza de PowerUps
+ * Simula 10,000 otorgamientos para verificar las distribuciones
+ */
+
+// Simular la función getAvailablePowerUpTypes()
+function getAvailablePowerUpTypes() {
+    return ['Fence', 'Shield', 'Pawn Range', 'Evolution', 'Cage', 'Blast', 
+            'Horizontal Portal', 'Extra Move', 'Crazy King', 'Reducer', 'Swap'];
+}
+
+// Copiar la función getRandomPowerUp() del juego
+function getRandomPowerUp() {
+    // Define PowerUp rarities with their probabilities
+    const powerUpRarities = {
+        // COMUNES (75% total) - 18.75% cada uno
+        'Fence': 18.75,
+        'Shield': 18.75,
+        'Pawn Range': 18.75,
+        'Evolution': 18.75,
+        
+        // RAROS (20% total) - 6.67% cada uno
+        'Cage': 6.67,
+        'Blast': 6.67,
+        'Horizontal Portal': 6.66,
+        
+        // LEGENDARIOS (5% total) - 1.25% cada uno
+        'Extra Move': 1.25,
+        'Crazy King': 1.25,
+        'Reducer': 1.25,
+        'Swap': 1.25
+    };
+    
+    // Get available power-up types
+    const availableTypes = getAvailablePowerUpTypes();
+    if (availableTypes.length === 0) {
+        console.warn("No power-up types available to grant.");
+        return null;
+    }
+    
+    // Filter rarities to only include available types
+    const availableRarities = {};
+    let totalWeight = 0;
+    
+    availableTypes.forEach(type => {
+        if (powerUpRarities[type]) {
+            availableRarities[type] = powerUpRarities[type];
+            totalWeight += powerUpRarities[type];
+        }
+    });
+    
+    if (totalWeight === 0) {
+        // Fallback to equal probability if no rarities defined
+        const randomIndex = Math.floor(Math.random() * availableTypes.length);
+        return availableTypes[randomIndex];
+    }
+    
+    // Generate random number and select based on weighted probability
+    const random = Math.random() * totalWeight;
+    let currentWeight = 0;
+    
+    for (const [type, weight] of Object.entries(availableRarities)) {
+        currentWeight += weight;
+        if (random <= currentWeight) {
+            return type;
+        }
+    }
+    
+    // Fallback (shouldn't reach here)
+    return availableTypes[0];
+}
+
+// Test function
+function testPowerUpProbabilities() {
+    const iterations = 10000;
+    const results = {};
+    
+    // Initialize counters
+    const allTypes = getAvailablePowerUpTypes();
+    allTypes.forEach(type => {
+        results[type] = 0;
+    });
+    
+    // Run test
+    console.log(`🧪 Ejecutando ${iterations} simulaciones de otorgamiento de PowerUps...`);
+    
+    for (let i = 0; i < iterations; i++) {
+        const powerUp = getRandomPowerUp();
+        if (powerUp) {
+            results[powerUp]++;
+        }
+    }
+    
+    // Calculate and display results
+    console.log('\n📊 RESULTADOS DE PROBABILIDAD:');
+    console.log('================================');
+    
+    // Group by rarity
+    const common = ['Fence', 'Shield', 'Pawn Range', 'Evolution'];
+    const rare = ['Cage', 'Blast', 'Horizontal Portal'];
+    const legendary = ['Extra Move', 'Crazy King', 'Reducer', 'Swap'];
+    
+    let commonTotal = 0, rareTotal = 0, legendaryTotal = 0;
+    
+    console.log('\n⚪ COMUNES (Target: ~18.75% cada uno, 75% total):');
+    common.forEach(type => {
+        const percentage = ((results[type] / iterations) * 100).toFixed(2);
+        console.log(`  ${type}: ${results[type]} (${percentage}%)`);
+        commonTotal += results[type];
+    });
+    
+    console.log('\n🔵 RAROS (Target: ~6.67% cada uno, 20% total):');
+    rare.forEach(type => {
+        const percentage = ((results[type] / iterations) * 100).toFixed(2);
+        console.log(`  ${type}: ${results[type]} (${percentage}%)`);
+        rareTotal += results[type];
+    });
+    
+    console.log('\n🟡 LEGENDARIOS (Target: ~1.25% cada uno, 5% total):');
+    legendary.forEach(type => {
+        const percentage = ((results[type] / iterations) * 100).toFixed(2);
+        console.log(`  ${type}: ${results[type]} (${percentage}%)`);
+        legendaryTotal += results[type];
+    });
+    
+    console.log('\n📈 RESUMEN POR RAREZA:');
+    console.log('=======================');
+    console.log(`⚪ Comunes: ${commonTotal} (${((commonTotal/iterations)*100).toFixed(1)}%) - Target: 75%`);
+    console.log(`🔵 Raros: ${rareTotal} (${((rareTotal/iterations)*100).toFixed(1)}%) - Target: 20%`);
+    console.log(`🟡 Legendarios: ${legendaryTotal} (${((legendaryTotal/iterations)*100).toFixed(1)}%) - Target: 5%`);
+    
+    const total = commonTotal + rareTotal + legendaryTotal;
+    console.log(`\n✅ Total verificado: ${total}/${iterations} (${((total/iterations)*100).toFixed(1)}%)`);
+}
+
+// Ejecutar el test
+testPowerUpProbabilities();


### PR DESCRIPTION
Implemente un sistema de aparicion de Powerups en este orden: 
COMUNES
- Fence: 18.67%
- Shield: 18.60% 
- Pawn Range: 18.76%
- Evolution: 18.55%

RAROS 
- Cage: 6.63%
- Blast: 6.94%
- Horizontal Portal: 6.43%

LEGENDARIOS 
- Extra Move: 1.31%
- Crazy King: 1.29%
- Reducer: 1.43%
- Swap: 1.39%

Despues agregue que los powerups no pudieran ser repetidos en el inventario del jugador, es decir que no pudieras tener powerups duplicados. Y tambien tal cual lo indica el juego cada 5 puntos te dan un powerup lo cual no estaba correctamente implementado entonces lo corregi.